### PR TITLE
Use require instead of require_relative for improved Ruby 1.8 support

### DIFF
--- a/lib/emoji/rspec/formatters.rb
+++ b/lib/emoji/rspec/formatters.rb
@@ -1,3 +1,3 @@
 Dir[File.join(File.dirname(__FILE__), 'formatters', '*.rb')].each do |file|
-  require_relative File.join('formatters', File.basename(file, '.rb'))
+  require file
 end


### PR DESCRIPTION
I tried [adding `emoji-rspec`](https://github.com/sferik/t/commit/14394158e9226b56252ef35493101ed4d60c9c06) to [one of my projects](https://github.com/sferik/t) but the [specs are failing on Ruby 1.8.7](https://travis-ci.org/sferik/t/jobs/4803975) due to your use of `require_relative`.

As far as I can tell, there's not reason not to simply use `require` here instead.
