### PR TITLE
Fix drinking game formatter

### DIFF
--- a/lib/emoji/rspec/formatters/drinking_game_formatter.rb
+++ b/lib/emoji/rspec/formatters/drinking_game_formatter.rb
@@ -1,4 +1,4 @@
-require 'rspec/core/formatters/base_text_formatter'
+require_relative 'base'
 
 module Emoji
   module RSpec


### PR DESCRIPTION
Hey!

Seems this change has been missed when formatters have been switched to use Base class (https://github.com/cupakromer/emoji-rspec/commit/4b889bb38dce944bae0c2fbc5efc6c03d8edc6b2).

Cheers!
