### PR TITLE
Support for RSpec 3...

### DIFF
--- a/examples/show_some_emoji.rb
+++ b/examples/show_some_emoji.rb
@@ -1,5 +1,6 @@
-# to run this, just do
-# rspec -r emoji_test_love/rspec examples/show_some_emoji.rb --format EmojiTestLove::SmileyFacesFormatter
+# to run this with...
+# rspec 2: rspec -r emoji_test_love/rspec examples/show_some_emoji.rb --format EmojiTestLove::SmileyFacesFormatter
+# rspec 3: rspec -r emoji_test_love/rspec3 examples/show_some_emoji.rb --format EmojiTestLove::SmileyFacesFormatter
 describe 'some tests to show off the magic!' do
   # generate many passes!
   50.times do |i|
@@ -9,7 +10,7 @@ describe 'some tests to show off the magic!' do
   end
 
   # generate some failures!
-  2.times do |i|
+  50.times do |i|
     it "fails, since #{i} is not #{i + 1}" do
       i.should == i + 1
     end
@@ -19,5 +20,3 @@ describe 'some tests to show off the magic!' do
     pending "don't care!"
   end
 end
-
-

--- a/lib/emoji-rspec.rb
+++ b/lib/emoji-rspec.rb
@@ -1,3 +1,11 @@
+def rspec3?
+  defined?(::RSpec::Core) && ::RSpec::Core::Version::STRING >= '3.0.0'
+end
+
 if defined? RSpec
-  require "emoji_test_love/rspec"
+  if rspec3?
+    require "emoji_test_love/rspec3"
+  else
+    require "emoji_test_love/rspec"
+  end
 end

--- a/lib/emoji_test_love/rspec3.rb
+++ b/lib/emoji_test_love/rspec3.rb
@@ -1,0 +1,45 @@
+require 'emoji_test_love/formatters'
+
+[
+  EmojiTestLove::AdventureTime,
+  EmojiTestLove::AggressiveThumbs,
+  EmojiTestLove::Books,
+  EmojiTestLove::Celebrate,
+  EmojiTestLove::DrinkingGame,
+  EmojiTestLove::DrinkingGameTea,
+  EmojiTestLove::Fruit,
+  EmojiTestLove::Kanpai,
+  EmojiTestLove::LifeHearts,
+  EmojiTestLove::Lucky,
+  EmojiTestLove::Omkase,
+  EmojiTestLove::SmileDip,
+  EmojiTestLove::Smiles,
+  EmojiTestLove::Sunshine,
+  EmojiTestLove::Thumbs,
+  EmojiTestLove::Turtles,
+  EmojiTestLove::Waddles,
+  EmojiTestLove::ZenSmiles,
+].each do |formatter|
+  formatter.class_eval do
+    def initialize(output)
+      @output = output
+    end
+
+    def example_passed(notification)
+      @output << passed_display
+    end
+
+    def example_failed(notification)
+      @output << failed_display
+    end
+
+    def example_pending(notification)
+      @output << pending_display
+    end
+  end
+
+  ::RSpec::Core::Formatters.register formatter,
+    :example_passed,
+    :example_failed,
+    :example_pending
+end

--- a/spec/generating_formatters_spec.rb
+++ b/spec/generating_formatters_spec.rb
@@ -1,3 +1,5 @@
+unless rspec3?
+
 require 'emoji_test_love/rspec/rspec_integration'
 
 module TestFormatter
@@ -139,5 +141,7 @@ describe "Generating a formatter" do
       ::EmojiTestLove::RSpecIntegration.known_formatters.each(&:names)
     end
   end
+
+end
 
 end

--- a/spec/support/shared_examples_for_formatters.rb
+++ b/spec/support/shared_examples_for_formatters.rb
@@ -1,4 +1,11 @@
 shared_examples "an Emoji Test Love Formatter" do
+  if rspec3?
+    subject { described_class.new(double) }
+    it { should respond_to :example_passed }
+    it { should respond_to :example_failed }
+    it { should respond_to :example_pending }
+  end
+
   it { should respond_to :passed_display }
   it { should respond_to :failed_display }
   it { should respond_to :pending_display }


### PR DESCRIPTION
Here's a first implementation. I find the `rspec3?` occurences within the tests a bit ugly, yet I haven't had an idea how to run the tests cleanly with both RSpec 2 and 3. I got a tip that I could use appraisal for this. I may look into this a bit more.

The entire generating_formatters_spec.rb (e.g. rspec_integration.rb) isn't needed in RSpec 3, as writing a custom formatter became a lot easier.

What do you think?
